### PR TITLE
Version 3.3

### DIFF
--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/controller/CategoryController.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/controller/CategoryController.java
@@ -6,6 +6,7 @@ import com.trendanalysis.service.CategoryService;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +16,8 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/category")
+@Slf4j
+@CrossOrigin(origins = "*", allowedHeaders = "*")
 @RequiredArgsConstructor
 public class CategoryController {
 
@@ -22,7 +25,12 @@ public class CategoryController {
 
     @GetMapping("/{categoryId}")
     public Response<CategoryResponseDto> list(@PathVariable ObjectId categoryId) {
-        return new Response<CategoryResponseDto>(true, 1000, categoryService.findOne(categoryId));
+        try {
+            return new Response<CategoryResponseDto>(true, 1000, categoryService.findOne(categoryId));
+        } catch (IllegalStateException e) {
+            log.info("존재하지 않는 카테고리", e);
+            return new Response<CategoryResponseDto>(false, 3000, null);
+        }
     }
 
     @GetMapping("/child/{categoryId}")
@@ -50,9 +58,14 @@ public class CategoryController {
                 .keywords(list)
                 .build();
 
-        Category save = categoryService.save(category);
+        try {
+            Category save = categoryService.save(category);
 
-        return new Response<Id>(true, 1000, new Id(save.getId().toString()));
+            return new Response<Id>(true, 1000, new Id(save.getId().toString()));
+        } catch (IllegalStateException e) {
+            log.info("카테고리 중복", e);
+            return new Response<Id>(false, 3001, new Id(null));
+        }
     }
 
     @PutMapping("/{categoryId}")

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/controller/ChartController.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/controller/ChartController.java
@@ -1,5 +1,7 @@
 package com.trendanalysis.controller;
 
+import com.trendanalysis.dto.ChartCategoryRequestDto;
+import com.trendanalysis.dto.ChartCategoryResponseDto;
 import com.trendanalysis.dto.ChartRequestDto;
 import com.trendanalysis.dto.ChartResponseDto;
 
@@ -9,11 +11,9 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-
-import java.util.List;
-
 @RestController
 @RequestMapping("/chart")
+@CrossOrigin(origins = "*", allowedHeaders = "*")
 @RequiredArgsConstructor
 public class ChartController {
 
@@ -25,6 +25,16 @@ public class ChartController {
         return new Response<>(true, 1000,
                 chartService.listSearchAmount(
                         chartRequestDto.getKeywordNames(),
+                        chartRequestDto.getStartDate().toString(),
+                        chartRequestDto.getEndDate().toString()));
+    }
+
+    @PostMapping("/category")
+    public Response<ChartCategoryResponseDto> ListDataAmountByCategory(@RequestBody ChartCategoryRequestDto chartRequestDto) {
+
+        return new Response<>(true, 1000,
+                chartService.listSearchAmount(
+                        chartRequestDto.getCategoryName(),
                         chartRequestDto.getStartDate().toString(),
                         chartRequestDto.getEndDate().toString()));
     }

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/controller/KeywordController.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/controller/KeywordController.java
@@ -7,6 +7,7 @@ import com.trendanalysis.service.KeywordService;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,6 +17,8 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/keyword")
+@Slf4j
+@CrossOrigin(origins = "*", allowedHeaders = "*")
 @RequiredArgsConstructor
 public class KeywordController {
 
@@ -23,7 +26,11 @@ public class KeywordController {
 
     @GetMapping("/{keywordId}")
     public Response<KeywordResponseDto> list(@PathVariable ObjectId keywordId) {
-        return new Response<KeywordResponseDto>(true, 1000, keywordService.findOne(keywordId));
+        try {
+            return new Response<KeywordResponseDto>(true, 1000, keywordService.findOne(keywordId));
+        } catch (IllegalStateException e) {
+            return new Response<KeywordResponseDto>(false, 2000, null);
+        }
     }
 
     @PostMapping("/")
@@ -35,9 +42,14 @@ public class KeywordController {
                 .categories(list)
                 .build();
 
-        Keyword save = keywordService.save(keyword, keywordRequestDto.getCategoryNames());
+        try {
+            Keyword save = keywordService.save(keyword, keywordRequestDto.getCategoryNames());
 
-        return new Response<Id>(true, 1000, new Id(save.getId().toString()));
+            return new Response<Id>(true, 1000, new Id(save.getId().toString()));
+        } catch (IllegalStateException e) {
+            log.info("키워드 중복", e);
+            return new Response<Id>(false, 2001, new Id(null));
+        }
     }
 
     @PutMapping("/{keywordId}")

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/dto/ChartCategoryRequestDto.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/dto/ChartCategoryRequestDto.java
@@ -1,0 +1,20 @@
+package com.trendanalysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+public class ChartCategoryRequestDto {
+
+    private String categoryName;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+}

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/dto/ChartCategoryResponseDto.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/dto/ChartCategoryResponseDto.java
@@ -1,0 +1,17 @@
+package com.trendanalysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ChartCategoryResponseDto {
+
+    private ChartResponseDto parentCategory;
+
+    private ChartResponseDto category;
+
+    private List<ChartResponseDto> childCategory;
+}

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/service/CategoryService.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/service/CategoryService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,12 +24,21 @@ public class CategoryService {
     private final KeywordRepository keywordRepository;
     private final KeywordService keywordService;
 
-    public Category save(Category category) {
-        return categoryRepository.save(category);
+    public Category save(Category category) throws IllegalStateException{
+       if(categoryRepository.findByName(category.getName()) != null){
+           throw new IllegalStateException("이미 존재하는 카테고리입니다.");
+       }
+           return categoryRepository.save(category);
     }
 
-    public CategoryResponseDto findOne(ObjectId categoryId) {
-        Category category = categoryRepository.findById(categoryId).get();
+    public CategoryResponseDto findOne(ObjectId categoryId) throws IllegalStateException {
+        Optional<Category> tempCategory = categoryRepository.findById(categoryId);
+        if (!tempCategory.isPresent()) {
+            throw new IllegalStateException("존재 하지 않는 카테고리 입니다.");
+        }
+
+        Category category = tempCategory.get();
+
         List<ObjectId> keywords = category.getKeywords();
 
         List<String> keywordNames = keywords.stream().map(id ->

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/service/ChartService.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/service/ChartService.java
@@ -1,13 +1,17 @@
 package com.trendanalysis.service;
 
+import com.trendanalysis.domain.Category;
+import com.trendanalysis.domain.Keyword;
+import com.trendanalysis.dto.ChartCategoryResponseDto;
 import com.trendanalysis.dto.ChartResponseDto;
 import com.trendanalysis.naver.*;
+import com.trendanalysis.repository.CategoryRepository;
+import com.trendanalysis.repository.KeywordRepository;
 import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static com.trendanalysis.dto.ChartResponseDto.*;
 import static com.trendanalysis.naver.NaverSearchRequestDto.*;
@@ -19,6 +23,8 @@ public class ChartService {
 
     private final NaverSearchService naverSearchService;
     private final NaverAdService naverAdService;
+    private final CategoryRepository categoryRepository;
+    private final KeywordRepository keywordRepository;
 
     public ChartResponseDto listSearchAmount(List<String> keywordNames,
                                                    String startedAt,
@@ -66,6 +72,58 @@ public class ChartService {
 
 
         return new ChartResponseDto(result);
+    }
+
+    public ChartCategoryResponseDto listSearchAmount(String categoryName,
+                                             String startedAt,
+                                             String endedAt) {
+
+        List<ChartResponseDto> list = new ArrayList<>();
+        Category category = categoryRepository.findByName(categoryName);
+
+        ChartResponseDto result = null;
+        ChartResponseDto parentResult = null;
+
+        //해당 카테고리의 키워드 검색량 조회
+        if (category.getKeywords().size() != 0) {
+            result = listDataByCategory(category, startedAt, endedAt);
+        }
+
+
+        //해당 카테고리의 부모 카테고리 키워드 검색량 조회
+        if (!Objects.equals(category.getParentId(), "")) {
+            Category parentCategory = categoryRepository.findById(new ObjectId(category.getParentId())).get();
+            if (parentCategory.getKeywords() == null) {
+                parentResult = null;
+            } else {
+                parentResult = listDataByCategory(parentCategory, startedAt, endedAt);
+            }
+        }
+
+        //해당 카테고리의 자식 카테고리 키워드 검색량 조회
+        List<Category> child = categoryRepository.findAllByParentId(category.getId().toString());
+
+        if (child.size() != 0) {
+            for (Category childCategory : child) {
+                if (childCategory.getKeywords().size() != 0) {
+                    list.add(listDataByCategory(childCategory, startedAt, endedAt));
+                }
+            }
+        }
+
+        return new ChartCategoryResponseDto(parentResult, result, list);
+    }
+
+    private ChartResponseDto listDataByCategory(Category category, String startedAt, String endedAt) {
+        List<ObjectId> keywordIds = category.getKeywords();
+        List<String> keywordNames = new ArrayList<>();
+
+        for (ObjectId id : keywordIds) {
+            Keyword keyword = keywordRepository.findById(id).get();
+            keywordNames.add(keyword.getName());
+        }
+
+        return listSearchAmount(keywordNames, startedAt, endedAt);
     }
 
     private NaverSearchResponseDto requestRatio(List<String> keywordNames, String startedAt, String endedAt) {

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/service/KeywordService.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/service/KeywordService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -20,8 +21,15 @@ public class KeywordService {
     private final KeywordRepository keywordRepository;
     private final CategoryRepository categoryRepository;
 
-    public KeywordResponseDto findOne(ObjectId keywordId) {
-        Keyword keyword = keywordRepository.findById(keywordId).get();
+    public KeywordResponseDto findOne(ObjectId keywordId) throws IllegalStateException {
+        Optional<Keyword> tempKeyword = keywordRepository.findById(keywordId);
+
+        if (!tempKeyword.isPresent()) {
+            throw new IllegalStateException("존재하지 않는 키워드입니다.");
+        }
+
+        Keyword keyword = tempKeyword.get();
+
         List<ObjectId> categoryIds = keyword.getCategories();
 
         List<String> categoryNames = categoryIds.stream().map(id ->
@@ -36,7 +44,7 @@ public class KeywordService {
         );
     }
 
-    public Keyword save(Keyword keyword, List<String> categoryNames) {
+    public Keyword save(Keyword keyword, List<String> categoryNames) throws IllegalStateException{
         if (keywordRepository.findByName(keyword.getName()) != null) {
             throw new IllegalStateException("이미 존재하는 키워드입니다.");
         }


### PR DESCRIPTION
- 3.1 개선점
    - 트러블 슈팅
        - 저번주 발표에서 발생한 NULL 예외는 에러 로그를 추적해본 결과, 날짜를 입력하면서 ,나 . 같이 포맷팅이 되지않는 문자를 입력한 것으로 확인
        - 한달이 초과하더라도 정상적으로 키워드 검색량이 나타나는 것을 확인 가능
    - 예외 처리
        - 중복된 키워드를 저장하려 하거나 존재하지 않는 키워드를 검색하는 것처럼 비지니스적으로 중요한 예외를 처리
            - 예) 중복된 키워드: 2001, 존재하지 않는 키워드: 2000
- 3.1 추가점
    - Keyword CRUD API 개발 완료
    - 카테고리별 키워드 검색량 API 개발 완료
- 이슈
    - Redis를 활용하여 캐싱 구현 진행