### PR TITLE
Version 4.1

### DIFF
--- a/back-end/trend-analysis/build.gradle
+++ b/back-end/trend-analysis/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation group: 'javax.xml.bind', name: 'jaxb-api'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/config/RedisConfig.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.trendanalysis.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Bean
+    public CacheManager userCacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(3L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(connectionFactory)
+                .cacheDefaults(redisCacheConfiguration).build();
+    }
+}

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/controller/ChartController.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/controller/ChartController.java
@@ -8,7 +8,9 @@ import com.trendanalysis.dto.ChartResponseDto;
 import com.trendanalysis.service.ChartService;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,6 +22,7 @@ public class ChartController {
     private final ChartService chartService;
 
     @PostMapping("/keyword")
+    @Cacheable(cacheNames = "keywordAmount", cacheManager = "userCacheManager")
     public Response<ChartResponseDto> ListDataAmount(@RequestBody ChartRequestDto chartRequestDto) {
 
         return new Response<>(true, 1000,
@@ -30,7 +33,9 @@ public class ChartController {
     }
 
     @PostMapping("/category")
-    public Response<ChartCategoryResponseDto> ListDataAmountByCategory(@RequestBody ChartCategoryRequestDto chartRequestDto) {
+    @Cacheable(cacheNames = "categoryAmount", cacheManager = "userCacheManager")
+    public Response<ChartCategoryResponseDto> ListDataAmountByCategory(
+            @RequestBody ChartCategoryRequestDto chartRequestDto) {
 
         return new Response<>(true, 1000,
                 chartService.listSearchAmount(
@@ -41,7 +46,8 @@ public class ChartController {
 
     @Data
     @AllArgsConstructor
-    private class Response <T> {
+    @NoArgsConstructor
+    private static class Response <T> {
         private Boolean isSuccess;
 
         private Integer code;

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/dto/ChartCategoryRequestDto.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/dto/ChartCategoryRequestDto.java
@@ -2,12 +2,14 @@ package com.trendanalysis.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class ChartCategoryRequestDto {
 
     private String categoryName;

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/dto/ChartCategoryResponseDto.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/dto/ChartCategoryResponseDto.java
@@ -2,11 +2,13 @@ package com.trendanalysis.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class ChartCategoryResponseDto {
 
     private ChartResponseDto parentCategory;

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/dto/ChartResponseDto.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/dto/ChartResponseDto.java
@@ -2,20 +2,26 @@ package com.trendanalysis.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
-@AllArgsConstructor
+@NoArgsConstructor
 public class ChartResponseDto {
 
     List<ChartKey> keywordList;
 
     @Data
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class ChartKey {
         private String keywordName;
 
         private List<Integer> searchAmount;
+    }
+
+    public ChartResponseDto(List<ChartKey> keywordList) {
+        this.keywordList = keywordList;
     }
 }

--- a/back-end/trend-analysis/src/main/java/com/trendanalysis/service/ChartService.java
+++ b/back-end/trend-analysis/src/main/java/com/trendanalysis/service/ChartService.java
@@ -78,7 +78,7 @@ public class ChartService {
                                              String startedAt,
                                              String endedAt) {
 
-        List<ChartResponseDto> list = new ArrayList<>();
+        List<ChartResponseDto> list = null;
         Category category = categoryRepository.findByName(categoryName);
 
         ChartResponseDto result = null;
@@ -104,6 +104,7 @@ public class ChartService {
         List<Category> child = categoryRepository.findAllByParentId(category.getId().toString());
 
         if (child.size() != 0) {
+            list = new ArrayList<>();
             for (Category childCategory : child) {
                 if (childCategory.getKeywords().size() != 0) {
                     list.add(listDataByCategory(childCategory, startedAt, endedAt));
@@ -138,15 +139,5 @@ public class ChartService {
 
         NaverSearchRequestDto request = new NaverSearchRequestDto(startedAt, endedAt, "date", keywordGroups);
         return naverSearchService.naverShopSearchAPI(request);
-    }
-
-    private List<Integer> findSearchAmount(String keyword) {
-        List<Integer> list = new ArrayList<>();
-
-        for (int i = 0; i < 20; i++) {
-            list.add(i);
-        }
-
-        return list;
     }
 }

--- a/back-end/trend-analysis/src/main/resources/application.yml
+++ b/back-end/trend-analysis/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   data:
     mongodb:
-      host: localhost
+      host: 3.39.227.41
       port: 27017
       database: trend_analysis
+
+  redis:
+    host: 52.79.171.168
+    port: 6379


### PR DESCRIPTION
- 4.1 개선점
    - Redis를 적용하여 검색량 API 응답속도 개선
        - 네이버 API가 상대값을 사용하기 때문에 날짜와 검색하는 키워드의 조합에 따라 항상 데이터가 변함
        - 따라서 날짜와 데이터의 조합이 동일해야 같은 데이터
        - 해당 조합의 데이터를 모두 사용하여 해시 함수를 통해 Redis 키 생성
        - 키워드별 검색량 API
            - 사용자가 제일 많이 사용할 것이라고 생각하는 한달 기준
            - 응답 속도 기준 약 4800% 성능 향상
            
            ![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/b428ee6e-1fd5-43cb-b288-7f57489da6eb/Untitled.png)
            
            ![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/20efccad-3aca-422b-9385-c2b2aa08a0dc/Untitled.png)
            
        - 카테고리별 검색량 API
            - 응답속도 기준 약 3600% 성능 향상
            
            ![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/a3542696-4787-4e36-8ba9-8e987d777397/Untitled.png)
            
            ![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/69a8226b-583e-46ff-b1ff-75e52aee6ab8/Untitled.png)
            
- 4.1 추가점
    - 캐싱을 위한 Redis 추가
        - In-memory DB 로서 빠른 응답속도 특징
- 이슈
    - TTL을 얼마나 설정하는 것이 좋을지 고민